### PR TITLE
move dependencies to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "url": "git@github.com:PiwikPRO/next-piwik-pro.git"
   },
   "dependencies": {
-    "@piwikpro/react-piwik-pro": "^1.1.1",
+    "@piwikpro/react-piwik-pro": "^1.1.1"
+  },
+  "peerDependencies": {
     "next": "^12.2.3",
     "react": "^18.2.0"
   },


### PR DESCRIPTION
## The case

In our next.js based project we've used `@piwikpro/next-piwik-pro`, while having 
 `"next": "12.1.4"` (fixed version) as our dependency.

Since `@piwikpro/next-piwik-pro` has `"next": "^12.2.3",` in its `dependencies` it resulted in us having two versions of `next` in `node_modules`.

As a consequence of having two `next` versions, we could not build the project.

To fix it - we updated our local `next` version to `"next": "12.2.3"` to keep it aligned with version which `@piwikpro/next-piwik-pro` uses.

## The problem

The real problem was - `@piwikpro/next-piwik-pro` has `next` as `dependency`, so it always installs it.

## The solution

To avoid customers fetching yet another next.js version, and at the same time have the dependency match - `peerDependencies` should be used.
 
[@piwikpro/react-piwik-pro](https://github.com/PiwikPRO/react-piwik-pro/tree/master), uses it correctly - https://github.com/PiwikPRO/react-piwik-pro/blob/master/package.json#L26

My change does the same.