### PR TITLE
docs: annotate deprecated 'accountName' prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export default function RootLayout({children}: {
 ```
 
 ```
-> Previously, we used 'accountName' to configure PiwikProProvider. The parameter has now been replaced by 'container-url'. The 'accountName' parameter is deprecated and will be removed in the future.
+> Previously, we used 'accountName' to configure PiwikProProvider. The parameter has now been replaced by 'containerUrl'. The 'accountName' parameter is deprecated and will be removed in the future.
 ```
 
 ### Setup with nonce

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 import { ReactNode } from 'react'
 
 export interface PiwikProProps {
+  /** @deprecated This parameter has now been replaced by 'containerId'. The 'accountName' parameter is deprecated and will be removed in the future. */
   accountName?: string
   containerId?: string
   containerUrl?: string


### PR DESCRIPTION
- Add jsdoc `@deprecated` tag to the `accountName` prop
- fix prop name in the readme