### PR TITLE
fix: bug when containerUrl ends with trailing slash

### DIFF
--- a/src/core/index.tsx
+++ b/src/core/index.tsx
@@ -32,6 +32,11 @@ export const PiwikProProvider: React.FC<PiwikProProviderProps> = ({
     PiwikProServices.DataLayer.setDataLayerName(dataLayerName)
   }
 
+   // Remove trailing slash from containerUrl if it exists
+   const sanitizedContainerUrl = containerUrl.endsWith('/')
+   ? containerUrl.slice(0, -1)
+   : containerUrl
+   
   return (
     <>
       <Script
@@ -41,7 +46,7 @@ export const PiwikProProvider: React.FC<PiwikProProviderProps> = ({
       >
         {`${PiwikPro.getInitScript({
           containerId,
-          containerUrl,
+          containerUrl: sanitizedContainerUrl,
           dataLayerName
         })}
     `}


### PR DESCRIPTION
When the provided containerUrl ends with a trailing slash, the generated url for the tracking js doesn't work. 

This fixes that problem by sanitising the input.